### PR TITLE
Fixed path issue for widgets upgrading from Qt4 to Qt5

### DIFF
--- a/bitcoin-qt-nix.pro
+++ b/bitcoin-qt-nix.pro
@@ -4,6 +4,7 @@ macx:TARGET = "GoldCoin-Qt"
 VERSION = 0.7.1.8
 INCLUDEPATH += src src/json src/qt
 QT += network
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE QT_STATIC_BUILD
 CONFIG += no_include_pwd
 CONFIG += thread


### PR DESCRIPTION
Added a line to include the widgets subdir that was changed between version Qt4 and Qt5.